### PR TITLE
Prevent Views to interact with Models directly 

### DIFF
--- a/MVVM-C.xcodeproj/project.pbxproj
+++ b/MVVM-C.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		65DD78761D116FEF00046364 /* DataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78741D116FEF00046364 /* DataItemViewModel.swift */; };
 		65DD78771D116FEF00046364 /* MVVMCDataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78751D116FEF00046364 /* MVVMCDataItemViewModel.swift */; };
+		65FF57A91D117D510090DF88 /* DataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78741D116FEF00046364 /* DataItemViewModel.swift */; };
+		65FF57AA1D117D510090DF88 /* MVVMCDataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78751D116FEF00046364 /* MVVMCDataItemViewModel.swift */; };
 		E241AB991CF35BF3005A2CCA /* MVVMCAuthenticateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E241AB981CF35BF3005A2CCA /* MVVMCAuthenticateViewModelTests.swift */; };
 		E241AB9B1CF35E14005A2CCA /* MVVMCAuthenticateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E296BBD11CEEEE9500420864 /* MVVMCAuthenticateModel.swift */; };
 		E241AB9C1CF35E1A005A2CCA /* AuthenticateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E296BBCA1CEEE94B00420864 /* AuthenticateModel.swift */; };
@@ -398,6 +400,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65FF57A91D117D510090DF88 /* DataItemViewModel.swift in Sources */,
+				65FF57AA1D117D510090DF88 /* MVVMCDataItemViewModel.swift in Sources */,
 				E241ABA81CF35EAE005A2CCA /* MVVMCDetailViewModel.swift in Sources */,
 				E241ABA71CF35EAE005A2CCA /* MVVMCListViewModel.swift in Sources */,
 				E241ABA21CF35EA9005A2CCA /* ListViewModel.swift in Sources */,

--- a/MVVM-C.xcodeproj/project.pbxproj
+++ b/MVVM-C.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		65DD78761D116FEF00046364 /* DataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78741D116FEF00046364 /* DataItemViewModel.swift */; };
+		65DD78771D116FEF00046364 /* MVVMCDataItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DD78751D116FEF00046364 /* MVVMCDataItemViewModel.swift */; };
 		E241AB991CF35BF3005A2CCA /* MVVMCAuthenticateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E241AB981CF35BF3005A2CCA /* MVVMCAuthenticateViewModelTests.swift */; };
 		E241AB9B1CF35E14005A2CCA /* MVVMCAuthenticateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E296BBD11CEEEE9500420864 /* MVVMCAuthenticateModel.swift */; };
 		E241AB9C1CF35E1A005A2CCA /* AuthenticateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E296BBCA1CEEE94B00420864 /* AuthenticateModel.swift */; };
@@ -65,6 +67,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		65DD78741D116FEF00046364 /* DataItemViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataItemViewModel.swift; sourceTree = "<group>"; };
+		65DD78751D116FEF00046364 /* MVVMCDataItemViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVVMCDataItemViewModel.swift; sourceTree = "<group>"; };
 		E241AB981CF35BF3005A2CCA /* MVVMCAuthenticateViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVVMCAuthenticateViewModelTests.swift; sourceTree = "<group>"; };
 		E241ABAB1CF44C84005A2CCA /* MVVMCListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVVMCListViewModelTests.swift; sourceTree = "<group>"; };
 		E241ABAD1CF45D44005A2CCA /* MVVMDetailViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVVMDetailViewModelTests.swift; sourceTree = "<group>"; };
@@ -126,6 +130,7 @@
 				E296BBC81CEEE89100420864 /* AuthenticateViewModel.swift */,
 				E24810141CF08B55002513B0 /* ListViewModel.swift */,
 				E24810311CF11303002513B0 /* DetailViewModel.swift */,
+				65DD78741D116FEF00046364 /* DataItemViewModel.swift */,
 			);
 			name = Protocols;
 			sourceTree = "<group>";
@@ -239,6 +244,7 @@
 			children = (
 				E24810161CF08B63002513B0 /* Protocols */,
 				E296BBCC1CEEEA6C00420864 /* MVVMCAuthenticateViewModel.swift */,
+				65DD78751D116FEF00046364 /* MVVMCDataItemViewModel.swift */,
 				E24810171CF08BC1002513B0 /* MVVMCListViewModel.swift */,
 				E24810331CF113A1002513B0 /* MVVMCDetailViewModel.swift */,
 			);
@@ -368,6 +374,7 @@
 				E25114631CED9DC100D9868B /* AppDelegate.swift in Sources */,
 				E296BBD21CEEEE9500420864 /* MVVMCAuthenticateModel.swift in Sources */,
 				E248101D1CF08C47002513B0 /* MVVMCListModel.swift in Sources */,
+				65DD78771D116FEF00046364 /* MVVMCDataItemViewModel.swift in Sources */,
 				E24810321CF11303002513B0 /* DetailViewModel.swift in Sources */,
 				E296BBC61CEDF21400420864 /* MVVMCAuthenticationViewController.swift in Sources */,
 				E296BBCB1CEEE94B00420864 /* AuthenticateModel.swift in Sources */,
@@ -375,6 +382,7 @@
 				E24810341CF113A1002513B0 /* MVVMCDetailViewModel.swift in Sources */,
 				E24810301CF11241002513B0 /* MVVMCDetailModel.swift in Sources */,
 				E296BBCD1CEEEA6C00420864 /* MVVMCAuthenticateViewModel.swift in Sources */,
+				65DD78761D116FEF00046364 /* DataItemViewModel.swift in Sources */,
 				E24810131CF08A7B002513B0 /* ListCoordinator.swift in Sources */,
 				E248101B1CF08C2D002513B0 /* ListModel.swift in Sources */,
 				E248102A1CF094B7002513B0 /* MVVMCItemTableViewCell.swift in Sources */,

--- a/MVVM-C/ViewModels/DataItemViewModel.swift
+++ b/MVVM-C/ViewModels/DataItemViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  DataItemViewModel.swift
+//  MVVM-C
+//
+//  Created by Daniel Carlos on 6/15/16.
+//  Copyright © 2016 Streambyte Limited. All rights reserved.
+//
+
+import Foundation
+
+protocol DataItemViewModel {
+    var name: String {get}
+    var role: String {get}
+    
+    init?(withDataItem: DataItem?)
+    
+}

--- a/MVVM-C/ViewModels/DetailViewModel.swift
+++ b/MVVM-C/ViewModels/DetailViewModel.swift
@@ -24,6 +24,6 @@ protocol DetailViewModel
     var model: DetailModel? { get set }
     var viewDelegate: DetailViewModelViewDelegate? { get set }
     var coordinatorDelegate: DetailViewModelCoordinatorDelegate? { get set}
-    var detail: DataItem? { get }
+    var detail: DataItemViewModel? { get }
     func done()
 }

--- a/MVVM-C/ViewModels/ListViewModel.swift
+++ b/MVVM-C/ViewModels/ListViewModel.swift
@@ -27,6 +27,6 @@ protocol ListViewModel
     var title: String { get }
     
     var numberOfItems: Int { get }
-    func itemAtIndex(index: Int) -> DataItem?
+    func itemAtIndex(index: Int) -> DataItemViewModel?
     func useItemAtIndex(index: Int)
 }

--- a/MVVM-C/ViewModels/MVVMCDataItemViewModel.swift
+++ b/MVVM-C/ViewModels/MVVMCDataItemViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  MVVMCDataItemViewModel.swift
+//  MVVM-C
+//
+//  Created by Daniel Carlos on 6/15/16.
+//  Copyright © 2016 Streambyte Limited. All rights reserved.
+//
+
+import Foundation
+
+struct MVVMCDataItemViewModel : DataItemViewModel{
+ 
+    var name : String
+    var role : String
+    
+    init?(withDataItem dataItem: DataItem?){
+        guard let item = dataItem else {
+            return nil
+        }
+        self.name = item.name
+        self.role = item.role
+    }
+    
+}

--- a/MVVM-C/ViewModels/MVVMCDetailViewModel.swift
+++ b/MVVM-C/ViewModels/MVVMCDetailViewModel.swift
@@ -14,7 +14,7 @@ class MVVMCDetailViewModel: DetailViewModel
     weak var viewDelegate: DetailViewModelViewDelegate?
     weak var coordinatorDelegate: DetailViewModelCoordinatorDelegate?
     
-    private(set) var detail: DataItem? {
+    private(set) var detail: DataItemViewModel? {
         didSet {
             viewDelegate?.detailDidChange(viewModel: self)
         }
@@ -23,7 +23,7 @@ class MVVMCDetailViewModel: DetailViewModel
     var model: DetailModel? {
         didSet {
             model?.detail({ (item) in
-                self.detail = item
+                self.detail = MVVMCDataItemViewModel(withDataItem: item)
             })
         }
     }

--- a/MVVM-C/ViewModels/MVVMCListViewModel.swift
+++ b/MVVM-C/ViewModels/MVVMCListViewModel.swift
@@ -41,10 +41,11 @@ class MVVMCListViewModel: ListViewModel
         return 0
     }
     
-    func itemAtIndex(index: Int) -> DataItem?
+    func itemAtIndex(index: Int) -> DataItemViewModel?
     {
         if let items = items where items.count > index {
-            return items[index]
+            let dataItem = items[index]
+            return MVVMCDataItemViewModel(withDataItem: dataItem)
         }
         return nil
     }

--- a/MVVM-C/Views/MVVMCItemTableViewCell.swift
+++ b/MVVM-C/Views/MVVMCItemTableViewCell.swift
@@ -12,7 +12,7 @@ class MVVMCItemTableViewCell: UITableViewCell {
 
     @IBOutlet weak var nameLabel: UILabel!
     
-    var item: DataItem? {
+    var item: DataItemViewModel? {
         didSet {
             if let item = item {
                 nameLabel.text = item.name


### PR DESCRIPTION
Create a ViewModel representation for DataItem, so that the Views can use it instead of using DataItem directly 
