### PR TITLE
Updated unit tests to Swift 3

### DIFF
--- a/MVVM-CTests/MVVMCAuthenticateViewModelTests.swift
+++ b/MVVM-CTests/MVVMCAuthenticateViewModelTests.swift
@@ -63,13 +63,13 @@ class MVVMCAuthenticateViewModelTests: XCTestCase
         let vm = MVVMCAuthenticateViewModel()
         vm.viewDelegate = self
         
-        currentExpectaion =  expectationWithDescription("estErrorMessageDidChange")
+        currentExpectaion =  expectation(description: "estErrorMessageDidChange")
         expectedErrorMessage = "Incomplete or Invalid Data";
         
         // Call submit with no model set on the viewModel should produce an error message
         vm.submit()
      
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectations(timeout: 1) { error in
             vm.viewDelegate = nil
         }
     }
@@ -80,14 +80,14 @@ class MVVMCAuthenticateViewModelTests: XCTestCase
         vm.model = MVVMCAuthenticateModel()
         
         vm.coordinatorDelegate = self
-        currentExpectaion =  expectationWithDescription("testCoordinatorDelegate")
+        currentExpectaion =  expectation(description: "testCoordinatorDelegate")
         
         vm.email = "scotty@example.com"
         vm.password = "password"
  
         vm.submit()
         
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectations(timeout: 1) { error in
             vm.coordinatorDelegate = nil
         }
     }
@@ -95,14 +95,14 @@ class MVVMCAuthenticateViewModelTests: XCTestCase
 
 extension MVVMCAuthenticateViewModelTests: AuthenticateViewModelViewDelegate
 {
-    func canSubmitStatusDidChange(viewModel: AuthenticateViewModel, status: Bool)
+    func canSubmitStatusDidChange(_ viewModel: AuthenticateViewModel, status: Bool)
     {
         XCTAssertEqual(expectedCanSubmit, status)
         XCTAssertEqual(expectedCanSubmit, viewModel.canSubmit)
         currentExpectaion?.fulfill()
     }
     
-    func errorMessageDidChange(viewModel: AuthenticateViewModel, message: String)
+    func errorMessageDidChange(_ viewModel: AuthenticateViewModel, message: String)
     {
         XCTAssertEqual(expectedErrorMessage, message)
         XCTAssertEqual(expectedErrorMessage, viewModel.errorMessage)
@@ -112,7 +112,7 @@ extension MVVMCAuthenticateViewModelTests: AuthenticateViewModelViewDelegate
 
 extension MVVMCAuthenticateViewModelTests: AuthenticateViewModelCoordinatorDelegate
 {
-    func authenticateViewModelDidLogin(viewModel viewModel: AuthenticateViewModel) {
+    func authenticateViewModelDidLogin(viewModel: AuthenticateViewModel) {
         currentExpectaion?.fulfill()
     }
 }

--- a/MVVM-CTests/MVVMCListViewModelTests.swift
+++ b/MVVM-CTests/MVVMCListViewModelTests.swift
@@ -93,10 +93,10 @@ class MVVMCListViewModelTests: XCTestCase
         // In normal testing we would create a ListModel implementation with fixed test data to use,
         vm.model = MVVMCListModel()
         vm.coordinatorDelegate = self
-        currentExpectaion =  expectationWithDescription("testUseItemAtIndex")
+        currentExpectaion =  expectation(description: "testUseItemAtIndex")
         vm.useItemAtIndex(6)
         
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectations(timeout: 1) { error in
             vm.coordinatorDelegate = nil
         }
     }
@@ -105,7 +105,7 @@ class MVVMCListViewModelTests: XCTestCase
 
 extension MVVMCListViewModelTests: ListViewModelCoordinatorDelegate
 {
-    func listViewModelDidSelectData(viewModel: ListViewModel, data: DataItem) {
+    func listViewModelDidSelectData(_ viewModel: ListViewModel, data: DataItem) {
         XCTAssertEqual("Pavel Chekov", data.name)
         XCTAssertEqual("Ensign", data.role)
         currentExpectaion?.fulfill()

--- a/MVVM-CTests/MVVMDetailViewModelTests.swift
+++ b/MVVM-CTests/MVVMDetailViewModelTests.swift
@@ -44,10 +44,10 @@ class MVVMDetailViewModelTests: XCTestCase
         expectedItem = MVVMCDataItem(name: "Test Name", role: "Test Role")
         let model = MVVMCDetailModel(detailItem: expectedItem!)
         vm.viewDelegate = self
-        currentExpectaion =  expectationWithDescription("testDetailDidChange")
+        currentExpectaion =  expectation(description: "testDetailDidChange")
         vm.model = model
         
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectations(timeout: 1) { error in
             vm.viewDelegate = nil
         }
     }
@@ -56,9 +56,9 @@ class MVVMDetailViewModelTests: XCTestCase
     {
         let vm = MVVMCDetailViewModel()
         vm.coordinatorDelegate = self
-        currentExpectaion =  expectationWithDescription("testDetailDidChange")
+        currentExpectaion =  expectation(description: "testDetailDidChange")
         vm.done()
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectations(timeout: 1) { error in
             vm.viewDelegate = nil
         }
    }
@@ -66,7 +66,7 @@ class MVVMDetailViewModelTests: XCTestCase
 
 extension MVVMDetailViewModelTests: DetailViewModelViewDelegate
 {
-    func detailDidChange(viewModel viewModel: DetailViewModel) {
+    func detailDidChange(viewModel: DetailViewModel) {
         XCTAssertNotNil(viewModel.detail)
         XCTAssertEqual(expectedItem?.name, viewModel.detail?.name)
         XCTAssertEqual(expectedItem?.role, viewModel.detail?.role)
@@ -76,7 +76,7 @@ extension MVVMDetailViewModelTests: DetailViewModelViewDelegate
 
 extension MVVMDetailViewModelTests: DetailViewModelCoordinatorDelegate
 {
-    func detailViewModelDidEnd(viewModel: DetailViewModel) {
+    func detailViewModelDidEnd(_ viewModel: DetailViewModel) {
         currentExpectaion?.fulfill()
     }
 }


### PR DESCRIPTION
I think you still have race conditions failing a few tests, but at least the compile issues are gone.  
